### PR TITLE
Adds platform.bing.com to yellowlist.txt

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -99,6 +99,7 @@ www.beyondmenu.com
 bigcommerce.com
 api.bilibili.com
 www.bilibili.com
+platform.bing.com
 r.bing.com
 www.bing.com
 bit.ly


### PR DESCRIPTION
Covers speech.platform.bing.com in support of the Edge Read aloud feature.